### PR TITLE
CAEN N957: Fix readout for large events and remove buffer size option

### DIFF
--- a/mca_api/drivers/caen_n957.py
+++ b/mca_api/drivers/caen_n957.py
@@ -201,7 +201,7 @@ class CaenN957MCA(DeviceMCA):
                     all_events_read = True
                     break
             if count != len(events_raw)>>1:
-                self.log("[EVENTCOUNT] MCA announced " + str(count) + " events, but " + str(len(events_raw)/2) + " received",level=0)
+                self.log(f"[EVENTCOUNT] MCA announced {count} events, but {len(events_raw)/2} received", level=0)
             for j in range(len(events_raw)>>1):
                 events = np.append(events, Util.to_int(events_raw[j*2:j*2+2])>>3)
             if all_events_read:


### PR DESCRIPTION
The buffer size option was broken and seems to not be relevant for end users, therefore it was removed.
Also, readout missed events in case of very large event counts (> 16384 events per readout, which is triggered up to every 150 ms), causing the device internal buffer to not be completely fetched and therefore events to accumulate. This is fixed by fetching as many events as possible.