### PR TITLE
v1.0.8: Fix CI for Linux release

### DIFF
--- a/.github/workflows/build-executables-reusable.yml
+++ b/.github/workflows/build-executables-reusable.yml
@@ -153,6 +153,9 @@ jobs:
     needs: [test-linux-debian11, test-linux-ubuntu]
     runs-on: ubuntu-latest
     steps:
+      # Check out git repository so "gh upload" can get repository information
+      - uses: actions/checkout@v4
+
       - name: Download Linux executable
         uses: actions/download-artifact@v4
         with:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     # Metadata
     name='imcar',
-    version='1.0.7',
+    version='1.0.8',
     author='2xB',
     author_email='2xB.coding@uni-muenster.de',
     long_description=long_description,


### PR DESCRIPTION
Beforehand, the Linux release failed since the GitHub CLI (for `gh upload`) required being in a repository to derive information it did not have access to now (resulting in `failed to run git: fatal: not a git repository (or any of the parent directories): .git`). This is fixed by checking out the repository.